### PR TITLE
Updating SemVer to In-house Flex Versioning

### DIFF
--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -127,26 +127,32 @@ jobs:
 # <----      Generate Unique Release Tag  ---- >
 
       
-      - name: Generate Unique Release Tag (SemVer)
+      - name: Generate Unique Release Tag (Custom Versioning)
         id: release-tag
         run: |
           # Fetch the latest tag from GitHub (ignoring errors if no tags exist yet)
           LATEST_TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null || echo "")
 
-          # If no tags exist, start with v0.0.0
-          if [[ -z "$LATEST_TAG" ]]; then
-            NEW_TAG="v0.1.0"
-          else
-            # Extract major, minor, and patch versions
-            MAJOR=$(echo "$LATEST_TAG" | cut -d. -f1 | sed 's/v//')
-            MINOR=$(echo "$LATEST_TAG" | cut -d. -f2)
-            PATCH=$(echo "$LATEST_TAG" | cut -d. -f3)
+          # Set default major version (manually updated when needed)
+          MAJOR=0  # You can manually update this when needed
 
-            # Increment the MINOR version and reset PATCH to 0
-            NEW_TAG="v$MAJOR.$((MINOR + 1)).0"
+          # If no tags exist, start with v0.1.0
+          if [[ -z "$LATEST_TAG" ]]; then
+            MINOR=1
+          else
+            # Extract minor version
+            MINOR=$(echo "$LATEST_TAG" | cut -d. -f2)
+            # Increment minor version
+            MINOR=$((MINOR + 1))
           fi
 
-          echo "Generated new SemVer release tag: $NEW_TAG"
+          # Fetch the number of merged PRs
+          PATCH=$(gh pr list --state merged --json number | jq 'length')
+
+          # Construct new version tag
+          NEW_TAG="v$MAJOR.$MINOR.$PATCH"
+
+          echo "Generated new custom release tag: $NEW_TAG"
           echo "RELEASE_TAG=$NEW_TAG" >> $GITHUB_ENV
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We are updating our versioning system to a in-house version that we created. 

How It Works:
	1.	MAJOR = Manually set (0 by default, you can update when needed).
	2.	MINOR = Increments every time a release is triggered.
	3.	PATCH = Matches the total number of merged PRs.
	4.	New tag is generated in the format: vMAJOR.MINOR.PATCH (e.g., v0.1.10).